### PR TITLE
Allow arguments to be passed to the script.

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -234,13 +234,13 @@ echo "\nWelcome friend to alleyinteractive/create-wordpress-plugin! 😀\nLet's 
 
 $author_name = ask(
 	question: 'Author name?',
-	default: run( 'git config user.name' ) ?: ( $args['author_name'] ?? '' ),
+	default: $args['author_name'] ?? run( 'git config user.name' ),
 	allow_empty: false,
 );
 
 $author_email = ask(
 	question: 'Author email?',
-	default: run( 'git config user.email' ) ?: ( $args['author_email'] ?? '' ),
+	default: $args['author_email'] ?? run( 'git config user.email' ),
 	allow_empty: false,
 );
 

--- a/configure.php
+++ b/configure.php
@@ -84,7 +84,6 @@ function writeln( string $line ): void {
 function run( string $command, string $dir = null ): string {
 	$command = $dir ? "cd {$dir} && {$command}" : $command;
 
-	return '';
 	return trim( shell_exec( $command ) );
 }
 


### PR DESCRIPTION
Allow default arguments to be passed to the script. Supports `author_name` and `author_email`. These would be defaults if the configure command cannot resolve the user's git username/email which are better defaults IMO. Cannot be used in tandem with the `make` command. Arguments must be passed directly to the PHP script like so:

```bash
php ./configure.php --author_name="Alley" --author_email info@alley.com
```

Fixes #83 