### PR TITLE
Update replacements in files for multi-word plugin names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Stable tag: 0.1.0
 
 Requires at least: 5.9
 
-Tested up to: 6.0
+Tested up to: 6.1
 
 Requires PHP: 8.0
 
@@ -82,7 +82,7 @@ You can also include an `index.php` file in the entry point directory for enqueu
 
 ### Scaffold a block with `create-block`
 
-Use the `create-block` command to create custom blocks with [`@wordpress/create-block`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/) and follow the prompts to generate all the block assets in the `blocks/` directory. 
+Use the `create-block` command to create custom blocks with [`@wordpress/create-block`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/) and follow the prompts to generate all the block assets in the `blocks/` directory.
 Block registration, script creation, etc will be scaffolded from the `bin/create-block/templates/block/` templates. Run `npm run build` to compile and build the custom block. Blocks are enqueued using the `load_scripts()` function in `src/assets.php`.
 
 ### Updating WP Dependencies

--- a/config/post-meta.json
+++ b/config/post-meta.json
@@ -1,12 +1,12 @@
 {
-  "create_wordpress_plugin_underscore_open_graph_description": {
+  "create_wordpress_plugin_open_graph_description": {
     "default": "",
     "post_types": [
       "page",
       "post"
     ]
   },
-  "create_wordpress_plugin_underscore_open_graph_image": {
+  "create_wordpress_plugin_open_graph_image": {
     "default": 0,
     "post_types": [
       "page",
@@ -14,7 +14,7 @@
     ],
     "type": "integer"
   },
-  "create_wordpress_plugin_underscore_open_graph_title": {
+  "create_wordpress_plugin_open_graph_title": {
     "default": "",
     "post_types": [
       "page",

--- a/configure.php
+++ b/configure.php
@@ -337,13 +337,13 @@ $search_and_replace = [
 	'Create_WordPress_Plugin'     => $namespace,
 	'Example_Plugin'              => $class_name,
 
-	'create_wordpress_plugin'     => str_replace( '-', '_', $plugin_name ),
+	'create_wordpress_plugin'     => str_replace( '-', '_', $plugin_name_slug ),
 	'plugin_name'                 => $plugin_name,
 
 	'create-wordpress-plugin'     => $plugin_name_slug,
 	'Create WordPress Plugin'     => $plugin_name,
 
-	'CREATE_WORDPRESS_PLUGIN'     => strtoupper( str_replace( '-', '_', $plugin_name ) ),
+	'CREATE_WORDPRESS_PLUGIN'     => strtoupper( str_replace( '-', '_', $plugin_name_slug ) ),
 	'Skeleton'                    => $class_name,
 	'vendor_name'                 => $vendor_name,
 	'alleyinteractive'            => $vendor_slug,
@@ -442,7 +442,7 @@ $standalone = true;
 if (
 	file_exists( '../../.git/index' )
 	&& ! confirm(
-		'Will this be a standalone plugin or will it be located within a larger project? For example, a standalone plugin will have a separate repository and will be distributed independently.',
+		'Will this be a standalone plugin, not located within a larger project? For example, a standalone plugin will have a separate repository and will be distributed independently.',
 		false,
 	)
 ) {

--- a/configure.php
+++ b/configure.php
@@ -194,7 +194,7 @@ function rollup_phpcs_to_parent( string $parent_file, string $local_file, string
 
   <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
     <properties>
-      <property name="prefixes" type="array" value="' . $plugin_domain . '" />
+      <property name="prefixes" type="array" value="' . str_replace( '-', '_', $plugin_domain ) . '" />
     </properties>
   </rule>
 </ruleset>';

--- a/plugin.php
+++ b/plugin.php
@@ -7,7 +7,7 @@
  * Author: author_name
  * Author URI: https://github.com/alleyinteractive/create-wordpress-plugin
  * Requires at least: 5.9
- * Tested up to: 5.9
+ * Tested up to: 6.1
  *
  * Text Domain: create-wordpress-plugin
  * Domain Path: /languages/
@@ -35,7 +35,7 @@ if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 		function() {
 			?>
 			<div class="notice notice-error">
-				<p><?php esc_html_e( 'Composer is not installed and create-wordpress-plugin cannot load. Try using a `*-built` branch if the plugin is being loaded as a submodule.', 'plugin_domain' ); ?></p>
+				<p><?php esc_html_e( 'Composer is not installed and create-wordpress-plugin cannot load. Try using a `*-built` branch if the plugin is being loaded as a submodule.', 'create-wordpress-plugin' ); ?></p>
 			</div>
 			<?php
 		}


### PR DESCRIPTION
* Fixes a few spots where string replacement failed when a plugin had a multi-word name.
* Updates WP support from 5.9 to 6.1.
* Updates standalone plugin prompt to be a yes/no question.