### PR TITLE
NPM: use `wp-scripts` for the `npm run dev` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "wp-scripts build --webpack-copy-php --webpack-src-dir=blocks",
     "create-block": "cd blocks && npx @wordpress/create-block --template ../bin/create-block --no-plugin",
-    "dev": "webpack --mode=development --watch",
+    "dev": "wp-scripts start --webpack-copy-php --webpack-src-dir=blocks",
     "lint:fix": "eslint --ext .jsx --ext .js . --fix",
     "lint": "eslint --ext .jsx --ext .js .",
     "packages-update": "wp-scripts packages-update",


### PR DESCRIPTION
As titled!

Unfortunately, the replacement for the `--watch` option in the `wp-scripts` package is the `--hot` option, but its support is [more involved](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#start): 

> --hot – enables “Fast Refresh”. The page will automatically reload if you make changes to the code. For now, it requires that WordPress has the [SCRIPT_DEBUG](https://wordpress.org/support/article/debugging-in-wordpress/#script_debug) flag enabled and the [Gutenberg](https://wordpress.org/plugins/gutenberg/) plugin installed.