### PR TITLE
Restore npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "wp-scripts build --webpack-copy-php --webpack-src-dir=blocks",
+    "dev": "npm run start",
     "create-block": "cd blocks && npx @wordpress/create-block --template ../bin/create-block --no-plugin",
     "lint:fix": "eslint --ext .jsx --ext .js . --fix",
     "lint": "eslint --ext .jsx --ext .js .",


### PR DESCRIPTION
Restore `npm run dev` (removed in #157) as an alias to `npm run start` to provide a consistent interface for starting scripts at Alley.