### PR TITLE
Add prompts to keep Alley plugins in line with the CONTRIBUTING.md file

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -509,8 +509,22 @@ $search_and_replace = [
 	'plugin.php'                  => $plugin_file,
 ];
 
+// Patch the Composer.json namespace first before search and replace.
+run(
+	'composer config extra.wordpress-autoloader.autoload --json \'' . json_encode( [
+		$namespace => 'src',
+	] ) . '\'',
+);
+
+run(
+	'composer config extra.wordpress-autoloader.autoload-dev --json \'' . json_encode( [
+		$namespace . '\\Tests' => 'tests',
+	] ) . '\'',
+);
+
 foreach ( list_all_files_for_replacement() as $path ) {
 	echo "Updating $path...\n";
+
 	replace_in_file( $path, $search_and_replace );
 
 	if ( str_contains( $path, determine_separator( 'src/class-example-plugin.php' ) ) ) {
@@ -522,6 +536,7 @@ foreach ( list_all_files_for_replacement() as $path ) {
 	}
 }
 
+// Attempt to rename the main plugin file.
 if ( 'plugin.php' !== $plugin_file ) {
 	rename( 'plugin.php', $plugin_file );
 

--- a/configure.php
+++ b/configure.php
@@ -489,6 +489,10 @@ $search_and_replace = [
 
 	'A skeleton WordPress plugin' => $description,
 
+	// Escape the namespace used in composer.json.
+	'"Create_WordPress_Plugin\\"'        => (string) json_encode( $namespace ),
+	'"Create_WordPress_Plugin\\Tests\\"' => (string) json_encode( $namespace . '\\Tests' ),
+
 	'Create_WordPress_Plugin'     => $namespace,
 	'Example_Plugin'              => $class_name,
 

--- a/configure.php
+++ b/configure.php
@@ -405,7 +405,7 @@ while ( true ) {
 	if ( $is_alley_plugin && 0 !== strpos( $plugin_name_slug, 'wp-' ) ) {
 		$example_slug = "wp-{$plugin_name_slug}";
 
-		contributing_message( "Alley Interactive WordPress plugin slugs should be prefixed with \"wp-\". For example, {$example_slug} would be a great slug. If this plugin isn't meant to be published anywhere, this is fine to ignore. See our CONTRIBUTING.md for more details." );
+		contributing_message( "Alley WordPress plugin slugs should be prefixed with \"wp-\". For example, {$example_slug} would be a great slug. If this plugin isn't meant to be published anywhere, this is fine to ignore. See our CONTRIBUTING.md for more details." );
 
 		if ( ! confirm( 'Do you wish to continue anyway?', false ) ) {
 			continue;
@@ -431,7 +431,7 @@ while ( true ) {
 	// Offer to fix the namespace if this is an Alley plugin.
 	if ( $is_alley_plugin && 0 !== strpos( $namespace, 'Alley\\WP\\' ) ) {
 		$example_namespace = 'Alley\\WP\\' . title_case( $plugin_name );
-		contributing_message( "Alley Interactive WordPress plugins should be prefixed with \"Alley\\WP\\\". A namespace such as \"{$example_namespace}\" would work well. If this plugin isn't meant to be published anywhere, this is fine to ignore. See our CONTRIBUTING.md for more details." );
+		contributing_message( "Alley WordPress plugins should be prefixed with \"Alley\\WP\\\". A namespace such as \"{$example_namespace}\" would work well. If this plugin isn't meant to be published anywhere, this is fine to ignore. See our CONTRIBUTING.md for more details." );
 
 		if ( confirm( 'Do you wish to continue anyway?', false ) ) {
 			break;

--- a/configure.php
+++ b/configure.php
@@ -26,24 +26,6 @@ if ( version_compare( PHP_VERSION, '8.0.0', '<' ) ) {
 	die( 'PHP 8.0.0 or greater is required.' );
 }
 
-// Get the width of the terminal.
-$terminal_width = (int) exec( 'tput cols' );
-
-function write( string $text, bool $include_new_line = false ): void {
-	global $terminal_width;
-
-	$lines    = explode( "\n", wordwrap( $text, $terminal_width - 1 ) );
-	$last_key = array_key_last( $lines );
-
-	foreach ( $lines as $i => $line ) {
-		if ( $include_new_line && $i === $last_key ) {
-			echo $line;
-		} else {
-			echo $line . PHP_EOL;
-		}
-	}
-}
-
 // Parse the command line arguments from $argv.
 $args         = [];
 $previous_key = null;
@@ -68,11 +50,17 @@ foreach ( $argv as $value ) {
 	}
 }
 
+$terminal_width = (int) exec( 'tput cols' );
+
+function write( string $text ): void {
+	global $terminal_width;
+	echo wordwrap( $text, $terminal_width - 1 ) . PHP_EOL;
+}
+
 function ask( string $question, string $default = '', bool $allow_empty = true ): string {
 	while ( true ) {
-		write( $question . ( $default ? " [{$default}]" : '' ) . ': ', true );
-
-		$answer = readline();
+		write( $question . ( $default ? " [{$default}]" : '' ) . ': ' );
+		$answer = readline( '> ' );
 
 		$value = $answer ?: $default;
 
@@ -86,9 +74,9 @@ function ask( string $question, string $default = '', bool $allow_empty = true )
 }
 
 function confirm( string $question, bool $default = false ): bool {
-	write( "{$question} (yes/no) [" . ( $default ? 'yes' : 'no' ) . ']: ', true );
+	write( "{$question} (yes/no) [" . ( $default ? 'yes' : 'no' ) . ']: ' );
 
-	$answer = readline();
+	$answer = readline( '> ' );
 
 	if ( ! $answer ) {
 		return $default;
@@ -96,7 +84,6 @@ function confirm( string $question, bool $default = false ): bool {
 
 	return in_array( strtolower( trim( $answer ) ), [ 'y', 'yes', 'true', '1' ], true );
 }
-
 
 function run( string $command, string $dir = null ): string {
 	$command = $dir ? "cd {$dir} && {$command}" : $command;

--- a/configure.php
+++ b/configure.php
@@ -26,6 +26,20 @@ if ( version_compare( PHP_VERSION, '8.0.0', '<' ) ) {
 	die( 'PHP 8.0.0 or greater is required.' );
 }
 
+// Get the width of the terminal.
+$terminal_width = (int) exec( 'tput cols' );
+
+// Write text to the terminal that will properly wrap.
+function write( string $text ): void {
+	global $terminal_width;
+
+	$lines = explode( "\n", wordwrap( $text, $terminal_width - 1 ) );
+
+	foreach ( $lines as $line ) {
+		echo $line . PHP_EOL;
+	}
+}
+
 // Parse the command line arguments from $argv.
 $args         = [];
 $previous_key = null;
@@ -75,10 +89,6 @@ function confirm( string $question, bool $default = false ): bool {
 	}
 
 	return in_array( strtolower( trim( $answer ) ), [ 'y', 'yes', 'true', '1' ], true );
-}
-
-function writeln( string $line ): void {
-	echo $line . PHP_EOL;
 }
 
 function run( string $command, string $dir = null ): string {
@@ -186,7 +196,7 @@ function remove_composer_files(): void {
 		]
 	);
 
-	echo 'Removed composer.json, composer.lock and vendor/ files.' . PHP_EOL;
+	write( 'Removed composer.json, composer.lock and vendor/ files.' );
 }
 
 function remove_project_files(): void {
@@ -204,7 +214,7 @@ function remove_project_files(): void {
 		]
 	);
 
-	echo 'Removed .buddy, buddy.yml, CHANGELOG.md, .deployignore, .editorconfig, .gitignore, .gitattributes, .github and LICENSE files.' . PHP_EOL;
+	write( 'Removed .buddy, buddy.yml, CHANGELOG.md, .deployignore, .editorconfig, .gitignore, .gitattributes, .github and LICENSE files.' );
 }
 
 function rollup_phpcs_to_parent( string $parent_file, string $local_file, string $plugin_name, string $plugin_domain ): void {
@@ -340,8 +350,8 @@ function remove_phpstan(): void {
 }
 
 function contributing_message( string $message ): void {
-	echo "\n{$message}\n";
-	echo "\n\t\e]8;;https://github.com/alleyinteractive/.github/blob/main/CONTRIBUTING.md#best-practices\e\\CONTRIBUTING.md\e]8;;\e\\\n\n";
+	write( "\n{$message}\n" );
+	echo "\t\e]8;;https://github.com/alleyinteractive/.github/blob/main/CONTRIBUTING.md#best-practices\e\\CONTRIBUTING.md\e]8;;\e\\\n\n";
 }
 
 echo "\nWelcome friend to alleyinteractive/create-wordpress-plugin! 😀\nLet's setup your WordPress Plugin 🚀\n\n";
@@ -462,17 +472,17 @@ while ( true ) {
 	break;
 }
 
-writeln( '------' );
-writeln( "Plugin      : {$plugin_name} <{$plugin_name_slug}>" );
-writeln( "Author      : {$author_name} ({$author_email})" );
-writeln( "Vendor      : {$vendor_name} ({$vendor_slug})" );
-writeln( "Description : {$description}" );
-writeln( "Namespace   : {$namespace}" );
-writeln( "Main File   : {$plugin_file}" );
-writeln( "Main Class  : {$class_name}" );
-writeln( '------' );
+write( '------' );
+write( "Plugin      : {$plugin_name} <{$plugin_name_slug}>" );
+write( "Author      : {$author_name} ({$author_email})" );
+write( "Vendor      : {$vendor_name} ({$vendor_slug})" );
+write( "Description : {$description}" );
+write( "Namespace   : {$namespace}" );
+write( "Main File   : {$plugin_file}" );
+write( "Main Class  : {$class_name}" );
+write( '------' );
 
-writeln( 'This script will replace the above values in all relevant files in the project directory.' );
+write( 'This script will replace the above values in all relevant files in the project directory.' );
 
 if ( ! confirm( 'Modify files?', true ) ) {
 	exit( 1 );


### PR DESCRIPTION
- Add some helpful prompts to keep the plugins in line with the [CONTRIBUTING.md](https://github.com/alleyinteractive/.github/blob/main/CONTRIBUTING.md) file
- Improves the output helper to ensure words don't get cutoff or cut mid word.