### PR TITLE
Make webpack dirpaths relative

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,11 +16,11 @@ module.exports = (env, { mode }) => ({
     return {
       ...blocks,
       ...fs
-        .readdirSync('./entries')
+        .readdirSync(path.join(__dirname, 'entries'))
         .reduce((acc, dirPath) => {
           acc[
             `entries-${dirPath}`
-          ] = `./entries/${dirPath}`;
+            ] = path.join(__dirname, 'entries', dirPath);
           return acc;
         }, {
           // All other custom entry points can be included here.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = (env, { mode }) => ({
         .reduce((acc, dirPath) => {
           acc[
             `entries-${dirPath}`
-            ] = path.join(__dirname, 'entries', dirPath);
+          ] = path.join(__dirname, 'entries', dirPath);
           return acc;
         }, {
           // All other custom entry points can be included here.


### PR DESCRIPTION
Fixes a bug whereby the directory paths specified in the webpack config are relative to the calling context instead of the location of the webpack config file itself. This change allows a user to run a `wp-scripts` build process from somewhere other than the root directory of the plugin, such as in the root of a project (the `wp-content` directory), like so:

```sh
wp-scripts build --config plugins/create-wordpress-plugin/webpack.config.js --webpack-copy-php --webpack-src-dir=plugins/create-wordpress-plugin/blocks
```