### PR TITLE
Copy SVG files with built block files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,11 @@ module.exports = (env, { mode }) => ({
           context: 'entries',
           noErrorOnMissing: true,
         },
+        {
+          from: '**/*.svg',
+          context: path.join(__dirname, 'blocks'),
+          noErrorOnMissing: true,
+        },
       ],
     }),
     new MiniCssExtractPlugin({


### PR DESCRIPTION
- When importing or referencering SVG files in src files, the file is not bundled with the built files.
- PR adds SVGs to file pattern in `CopyWebpackPlugin` so the files are copied into the built folder.