### PR TITLE
Composer defaults to `indent_size = 2`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,11 +12,6 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-# Composer File
-[composer.{json,lock}]
-indent_style = space
-indent_size = 4
-
 # Dotfiles
 [.*]
 indent_style = space


### PR DESCRIPTION
I usually do this manually in my project, but I haven't seen this being recommended anywhere:

- https://developer.wordpress.org/coding-standards/wordpress-coding-standards/
- https://docs.wpvip.com/technical-references/vip-codebase/editorconfig/
- https://github.com/ntwb/wordpress/blob/master/.editorconfig

Could you consider defaulting to 2 instead of 4?
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Chore: Updated `.editorconfig` settings. We've removed specific configuration for Composer files, namely `composer.json` and `composer.lock`. This change is minor and doesn't affect the functionality of the software. It's part of our ongoing efforts to streamline and simplify our codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

@coderabbitai: ignore