### PR TITLE
Bumping to mantle-framework/testkit v1 and PHPUnit 10

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.1, 8.2]
         wordpress: ["latest"]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
     with:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Requires at least: 5.9
 
 Tested up to: 6.1
 
-Requires PHP: 8.0
+Requires PHP: 8.1
 
 License: GPL v2 or later
 

--- a/buddy.yml
+++ b/buddy.yml
@@ -53,7 +53,7 @@
         - "echo \"extension=memcache.so\" >> /usr/local/etc/php/conf.d/buddy.ini"
       services:
         - type: "MYSQL"
-          version: "8.0"
+          version: "1"
           connection:
             host: "mysql"
             port: 3306

--- a/buddy.yml
+++ b/buddy.yml
@@ -53,7 +53,7 @@
         - "echo \"extension=memcache.so\" >> /usr/local/etc/php/conf.d/buddy.ini"
       services:
         - type: "MYSQL"
-          version: "1"
+          version: "8.0"
           connection:
             host: "mysql"
             port: 3306

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^2.0",
-        "mantle-framework/testkit": "^0.12",
+        "mantle-framework/testkit": "^1.0",
         "szepeviktor/phpstan-wordpress": "^1.1"
     },
     "config": {

--- a/configure.php
+++ b/configure.php
@@ -24,8 +24,8 @@ if ( 0 === strpos( strtoupper( PHP_OS ), 'WIN' ) ) {
 	die( 'Not supported in Windows. 🪟' );
 }
 
-if ( version_compare( PHP_VERSION, '8.0.0', '<' ) ) {
-	die( 'PHP 8.0.0 or greater is required.' );
+if ( version_compare( PHP_VERSION, '8.1.0', '<' ) ) {
+	die( 'PHP 8.1.0 or greater is required.' );
 }
 
 // Parse the command line arguments from $argv.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,6 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
-	printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
 >
 	<testsuites>
 		<testsuite name="Feature">


### PR DESCRIPTION
- Upgrades to Testkit version 1.0 and PHPUnit 10.
- Bumps PHP to 8.1+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the PHP version requirement in the README to reflect the new minimum version of 8.1.

- **Chores**
	- Modified the continuous integration workflow to test against PHP versions 8.1 and 8.2, dropping support for version 8.0.

- **Bug Fixes**
	- Adjusted the version check in the configuration to enforce the new PHP version requirement of 8.1.0 or greater.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->