### PR TITLE
Support windows path in validate_file checks

### DIFF
--- a/src/assets.php
+++ b/src/assets.php
@@ -16,7 +16,7 @@ namespace Create_WordPress_Plugin;
  * @return bool        True if the path is valid and the file exists.
  */
 function validate_path( string $path ): bool {
-	return 0 === validate_file( $path ) && file_exists( $path );
+	return ( 0 === validate_file( $path ) || 2 === validate_file( $path ) ) && file_exists( $path );
 }
 
 /**

--- a/src/assets.php
+++ b/src/assets.php
@@ -119,7 +119,7 @@ function load_scripts(): void {
 
 	if ( ! empty( $files ) ) {
 		foreach ( $files as $path ) {
-			if ( 0 === validate_file( $path ) && file_exists( $path ) ) {
+			if ( validate_path( $path ) ) {
 				require_once $path;  // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.IncludingFile, WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 			}
 		}

--- a/src/meta.php
+++ b/src/meta.php
@@ -135,9 +135,7 @@ function register_meta_helper(
 function register_post_meta_from_defs(): void {
 	// Ensure the config file exists.
 	$filepath = dirname( __DIR__ ) . '/config/post-meta.json';
-	if ( ! file_exists( $filepath )
-		|| 0 !== validate_file( $filepath )
-	) {
+	if ( ! validate_path( $filepath ) ) {
 		return;
 	}
 


### PR DESCRIPTION
### Summary
Fixes #296 where the code checks paths for "validity" by checking the return value of `validate_file` to ensure that it is `0`, but a valid Windows filepath on a Windows system will return `2`, making it so that this plugin cannot run on a Windows host (either for local development or via Windows Server).

### What changed
This PR replaces the `validate_file` check to ensure it returns either `0` or `2`.
* [fix validate_path function where validate_file checks for 0 or 2](https://github.com/alleyinteractive/create-wordpress-plugin/commit/4511b021c70892f5d35fa391007c379a0b17c13a)
* [fix validate_file on Windows for load_scripts function](https://github.com/alleyinteractive/create-wordpress-plugin/commit/8e5d23005ee3b16828dc634b39f345b5d7024ee5)
* [fix the validate_file error in the register_post_meta_from_defs function](https://github.com/alleyinteractive/create-wordpress-plugin/commit/83943679891dddda81ce89c46de85f4c454cbd19)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved path validation logic to enhance security and maintainability.
	- Streamlined script loading process by utilizing the updated path validation function.

- **Bug Fixes**
	- Adjusted path validation to correctly handle additional valid cases, reducing false negatives in file checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->