### PR TITLE
Move main plugin function into its own file

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -17,8 +17,6 @@
 
 namespace Create_WordPress_Plugin;
 
-use Alley\WP\Features\Group;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -60,13 +58,8 @@ if ( ! file_exists( __DIR__ . '/vendor/wordpress-autoload.php' ) ) {
 // Load the plugin's main files.
 require_once __DIR__ . '/src/assets.php';
 require_once __DIR__ . '/src/meta.php';
+require_once __DIR__ . '/src/main.php';
 
-/**
- * Instantiate the plugin.
- */
-function main(): void {
-	// Add features here.
-	$plugin = new Group();
-	$plugin->boot();
-}
+load_scripts();
+register_post_meta_from_defs();
 main();

--- a/src/assets.php
+++ b/src/assets.php
@@ -125,5 +125,3 @@ function load_scripts(): void {
 		}
 	}
 }
-
-load_scripts();

--- a/src/main.php
+++ b/src/main.php
@@ -18,4 +18,3 @@ function main(): void {
 
 	$plugin->boot();
 }
-

--- a/src/main.php
+++ b/src/main.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * The main plugin function
+ *
+ * @package create-wordpress-plugin
+ */
+
+namespace Create_WordPress_Plugin;
+
+use Alley\WP\Features\Group;
+
+/**
+ * Instantiate the plugin.
+ */
+function main(): void {
+	// Add features here.
+	$plugin = new Group();
+
+	$plugin->boot();
+}
+

--- a/src/meta.php
+++ b/src/meta.php
@@ -7,9 +7,6 @@
 
 namespace Create_WordPress_Plugin;
 
-// Register custom meta fields.
-register_post_meta_from_defs();
-
 /**
  * Register meta for posts or terms with sensible defaults and sanitization.
  *


### PR DESCRIPTION
Shuffles things around a bit:

- Declare the `main()` function in its own file, not in the middle of the plugin file.
- Make all function calls in the plugin file, not in the individual includes.

The upshot is that the include files contain only functions, and statements happen in the plugin file.