### PR TITLE
Fixes a syntax error in configure.php

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -418,7 +418,7 @@ function enable_sqlite_testing(): void {
 			),
 		);
 	}
-}-
+}
 
 // ---------------------------------------------------------
 // Start of the script. Above this line are the functions.


### PR DESCRIPTION
As titled. This fixes a syntax error in the configure script.