### PR TITLE
Changing default namespace to match organization standard

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -37,6 +37,7 @@
     <properties>
       <property name="prefixes" type="array">
         <element value="vendor_name" />
+        <element value="alley" />
         <element value="create_wordpress_plugin" />
       </property>
     </properties>

--- a/.scaffolder/plugin-feature/feature.php.hbs
+++ b/.scaffolder/plugin-feature/feature.php.hbs
@@ -5,7 +5,7 @@
  * @package Create_WordPress_Plugin
  */
 
-namespace Create_WordPress_Plugin\\{{ wpNamespace inputs.featureName prefix="Features" }};
+namespace Alley\WP\Create_WordPress_Plugin\\{{ wpNamespace inputs.featureName prefix="Features" }};
 
 use Alley\WP\Types\Feature;
 

--- a/.scaffolder/plugin-feature/test.php.hbs
+++ b/.scaffolder/plugin-feature/test.php.hbs
@@ -5,7 +5,7 @@
  * @package create-wordpress-plugin
  */
 
-namespace Create_WordPress_Plugin\\{{ wpNamespace inputs.featureName prefix="Tests\Features" }};
+namespace Alley\WP\Create_WordPress_Plugin\\{{ wpNamespace inputs.featureName prefix="Tests\Features" }};
 
 use Create_WordPress_Plugin\Tests\TestCase;
 use Create_WordPress_Plugin\\{{ wpNamespace inputs.featureName prefix="Features" }}\\{{ wpClassName inputs.featureName }};

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+MAKEFLAGS += --no-builtin-rules
+
 setup:
 	php ./configure.php
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Run `npm run lint` to run ESLint against all JavaScript files. Linting will also
 happen when running development or production builds.
 
 Run `composer test` to run tests against PHPUnit and the PHP code in the plugin.
+Unit testing code is written in PSR-4 format and can be found in the `tests`
+directory.
 
 ### The `entries` directory and entry points
 

--- a/composer.json
+++ b/composer.json
@@ -34,16 +34,13 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Create_WordPress_Plugin\\Tests\\": "tests"
+            "Alley\\WP\\Create_WordPress_Plugin\\Tests\\": "tests"
         }
     },
     "extra": {
         "wordpress-autoloader": {
             "autoload": {
-                "Create_WordPress_Plugin\\": "src"
-            },
-            "autoload-dev": {
-                "Create_WordPress_Plugin\\Tests\\": "tests"
+                "Alley\\WP\\Create_WordPress_Plugin\\": "src"
             }
         }
     },

--- a/configure.php
+++ b/configure.php
@@ -478,7 +478,7 @@ $plugin_name = ask(
 while ( true ) {
 	$plugin_name_slug = slugify( ask(
 		question: 'Plugin slug?',
-		default: slugify( $plugin_name ),
+		default: 'wp-' . ltrim( slugify( $plugin_name ), 'wp-' ),
 		allow_empty: false,
 	) );
 
@@ -514,8 +514,8 @@ while ( true ) {
 		$example_namespace = 'Alley\\WP\\' . title_case( $plugin_name );
 		contributing_message( "Alley WordPress plugins should be prefixed with \"Alley\\WP\\\". A namespace such as \"{$example_namespace}\" would work well. If this plugin isn't meant to be published anywhere, this is fine to ignore. See our CONTRIBUTING.md for more details." );
 
-		if ( confirm( 'Do you wish to continue anyway?', false ) ) {
-			break;
+		if ( ! confirm( 'Do you wish to continue anyway?', false ) ) {
+			continue;
 		}
 	}
 

--- a/configure.php
+++ b/configure.php
@@ -14,7 +14,7 @@
  * phpcs:disable
  */
 
-namespace Create_WordPress_Plugin\Configure;
+namespace Alley\WP\Create_WordPress_Plugin\Configure;
 
 if ( ! defined( 'STDIN' ) ) {
 	die( 'Not in CLI mode.' );
@@ -566,13 +566,11 @@ $search_and_replace = [
 
 	'A skeleton WordPress plugin' => $description,
 
-	// Escape the namespace used in composer.json.
-	'"Create_WordPress_Plugin\\"'        => (string) json_encode( $namespace ),
-	'"Create_WordPress_Plugin\\Tests\\"' => (string) json_encode( $namespace . '\\Tests' ),
+	// Extra slashes are here for composer.json.
+	'Alley\\\WP\\\Create_WordPress_Plugin\\\\' => str_replace( '\\', '\\\\', $namespace ) . '\\\\',
+	'Alley\WP\Create_WordPress_Plugin'         => $namespace,
 
-	'Create_WordPress_Plugin'     => $namespace,
 	'Example_Plugin'              => $class_name,
-
 	'create_wordpress_plugin'     => str_replace( '-', '_', $plugin_name_slug ),
 	'plugin_name'                 => $plugin_name,
 
@@ -585,19 +583,6 @@ $search_and_replace = [
 	'alleyinteractive'            => $vendor_slug,
 	'plugin.php'                  => $plugin_file,
 ];
-
-// Patch the Composer.json namespace first before search and replace.
-run(
-	'composer config extra.wordpress-autoloader.autoload --json \'' . json_encode( [
-		$namespace => 'src',
-	] ) . '\'',
-);
-
-run(
-	'composer config extra.wordpress-autoloader.autoload-dev --json \'' . json_encode( [
-		$namespace . '\\Tests' => 'tests',
-	] ) . '\'',
-);
 
 foreach ( list_all_files_for_replacement() as $path ) {
 	echo "Updating $path...\n";

--- a/plugin.php
+++ b/plugin.php
@@ -15,7 +15,7 @@
  * @package create-wordpress-plugin
  */
 
-namespace Create_WordPress_Plugin;
+namespace Alley\WP\Create_WordPress_Plugin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/src/assets.php
+++ b/src/assets.php
@@ -7,7 +7,7 @@
  * @package create-wordpress-plugin
  */
 
-namespace Create_WordPress_Plugin;
+namespace Alley\WP\Create_WordPress_Plugin;
 
 /**
  * Validate file paths to prevent a PHP error if a file doesn't exist.

--- a/src/class-example-plugin.php
+++ b/src/class-example-plugin.php
@@ -5,7 +5,7 @@
  * @package create-wordpress-plugin
  */
 
-namespace Create_WordPress_Plugin;
+namespace Alley\WP\Create_WordPress_Plugin;
 
 /**
  * Example Plugin

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -51,7 +51,7 @@ This is a port of the infamous WordPress `hello.php` plugin to a feature. The ly
  * @package Create_WordPress_Plugin
  */
 
-namespace Create_WordPress_Plugin\Features;
+namespace Alley\WP\Create_WordPress_Plugin\Features;
 
 use Alley\WP\Types\Feature;
 

--- a/src/main.php
+++ b/src/main.php
@@ -5,7 +5,7 @@
  * @package create-wordpress-plugin
  */
 
-namespace Create_WordPress_Plugin;
+namespace Alley\WP\Create_WordPress_Plugin;
 
 use Alley\WP\Features\Group;
 

--- a/src/meta.php
+++ b/src/meta.php
@@ -5,7 +5,7 @@
  * @package create-wordpress-plugin
  */
 
-namespace Create_WordPress_Plugin;
+namespace Alley\WP\Create_WordPress_Plugin;
 
 /**
  * Register meta for posts or terms with sensible defaults and sanitization.

--- a/tests/Feature/ExampleFeatureTest.php
+++ b/tests/Feature/ExampleFeatureTest.php
@@ -5,9 +5,9 @@
  * @package create-wordpress-plugin
  */
 
-namespace Create_WordPress_Plugin\Tests\Feature;
+namespace Alley\WP\Create_WordPress_Plugin\Tests\Feature;
 
-use Create_WordPress_Plugin\Tests\TestCase;
+use Alley\WP\Create_WordPress_Plugin\Tests\TestCase;
 
 /**
  * A test suite for an example feature.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,7 +5,7 @@
  * @package create-wordpress-plugin
  */
 
-namespace Create_WordPress_Plugin\Tests;
+namespace Alley\WP\Create_WordPress_Plugin\Tests;
 
 use Mantle\Testkit\Test_Case as TestkitTest_Case;
 

--- a/tests/Unit/ExampleUnitTest.php
+++ b/tests/Unit/ExampleUnitTest.php
@@ -5,7 +5,7 @@
  * @package create-wordpress-plugin
  */
 
-namespace Create_WordPress_Plugin\Tests\Unit;
+namespace Alley\WP\Create_WordPress_Plugin\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
Change the namespace used in our plugin to match the organization's standards. Ensure that the namespace is properly escaped in `composer.json` when search and replacing.