### PR TITLE
Issue-223: Reset browserslist config to default

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,6 @@
     "node": "22",
     "npm": "10"
   },
-  "browserslist": [
-    "defaults",
-    "not IE 11"
-  ],
   "scripts": {
     "build": "alley-build build",
     "create-block": "npx @alleyinteractive/create-block@latest -n create-wordpress-plugin",


### PR DESCRIPTION
## Summary
Removes the browserslist config from package.json so that the browserslist default configuration is used. The config we were previously using (defaults + no IE 11) is the same as the browserslist default, because the browserslist default includes "not dead" and IE11 is dead. There is no functional difference in what we already had in the repo vs. what the current defaults are from browserslist, so maintaining the extra configuration is unnecessary and redundant.

Fixes #223

## Changes
- Remove the `browserslist` entry from `package.json`.