### PR TITLE
Issue-418: Bump versions in documentation

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -7,7 +7,8 @@
  * Author: author_name
  * Author URI: https://github.com/alleyinteractive/create-wordpress-plugin
  * Requires at least: 5.9
- * Tested up to: 6.2
+ * Requires PHP: 8.2
+ * Tested up to: 6.7
  *
  * Text Domain: create-wordpress-plugin
  * Domain Path: /languages/


### PR DESCRIPTION
### Summary

Fixes #418

This pull request addresses the documentation inaccuracy by:
1. Setting the minimum PHP version to `8.2` (aligning with the PHP test matrix versions).
2. Updating the "tested up to" value to `6.7`.

### Changes Made

- Added the minimum PHP version (`8.2`) to the plugin's main file.
- Updated the "tested up to" value to `6.7` in the documentation.

### Additional Notes

The minimum PHP version was previously missing in the plugin's main file and has now been included to ensure clarity and alignment with testing configurations.
