### PR TITLE
Adding a Rector configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 /.phpcs.xml export-ignore
 /.phpcs export-ignore
 /phpunit.xml export-ignore
+/rector.php export-ignore
 /tests export-ignore
 /configure.php export-ignore
 /Makefile export-ignore

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^2.0",
         "mantle-framework/testkit": "^1.4",
+        "rector/rector": "^2.0",
         "szepeviktor/phpstan-wordpress": "^2.0"
     },
     "config": {
@@ -52,12 +53,16 @@
         "phpstan": "phpstan --memory-limit=512M",
         "lint": [
             "@phpcs",
-            "@phpstan"
+            "@phpstan",
+            "@rector"
         ],
         "lint:fix": [
-            "@phpcbf"
+          "@rector:fix",
+          "@phpcbf"
         ],
         "phpunit": "phpunit",
+        "rector:fix": "rector process",
+        "rector": "rector process --dry-run",
         "release": "npx @alleyinteractive/create-release@latest",
         "test": [
             "@phpcs",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Rector Configuration
+ *
+ * @link https://getrector.com/documentation
+ * @package create-wordpress-plugin
+ */
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+
+return RectorConfig::configure()
+	->withParallel()
+	->withIndent(
+		indentChar: '	',
+		indentSize: 1,
+	)
+	->withRootFiles()
+	->withPaths( [
+		__DIR__ . '/src',
+		__DIR__ . '/tests',
+	] )
+	/**
+	 * --------------------------------------------------------------------------
+	 * Enabled rector rules/rulesets.
+	 * --------------------------------------------------------------------------
+	 *
+	 * @link https://getrector.com/find-rule
+	 */
+	->withPreparedSets(
+		codeQuality: true,
+		deadCode: true,
+		earlyReturn: true,
+		typeDeclarations: true,
+	)
+	/**
+	 * --------------------------------------------------------------------------
+	 * Enable Rector to keep your code up-to-date with the latest features from the PHP version in your composer.json file
+	 * --------------------------------------------------------------------------
+	 */
+	->withPhpSets()
+	->withSets( [
+		PHPUnitSetList::PHPUNIT_100,
+		PHPUnitSetList::PHPUNIT_110,
+		PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
+	] )
+	/**
+	 * --------------------------------------------------------------------------
+	 * Rector rules to skip.
+	 * --------------------------------------------------------------------------
+	 *
+	 * @link https://getrector.com/documentation/ignoring-rules-or-paths
+	 */
+	->withSkip( [
+		Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector::class,
+	] );

--- a/src/assets.php
+++ b/src/assets.php
@@ -24,8 +24,6 @@ function validate_path( string $path ): bool {
  *
  * @param string  $dir_entry_name The directory name where the entry point was defined.
  * @param boolean $dir            Optional. Whether to return the directory path or the plugin URL path. Defaults to false (returns URL).
- *
- * @return string
  */
 function get_entry_dir_path( string $dir_entry_name, bool $dir = false ): string {
 	// The relative path from the plugin root.
@@ -35,7 +33,7 @@ function get_entry_dir_path( string $dir_entry_name, bool $dir = false ): string
 
 	if ( validate_path( $asset_dir_path ) ) {
 		// Negotiate the base path.
-		return true === $dir
+		return $dir
 			? $asset_dir_path
 			: plugins_url( $asset_build_dir, __DIR__ );
 	}
@@ -97,7 +95,7 @@ function get_asset_version( string $dir_entry_name ): string {
  * @param string $filename       The asset file name including the file type extension to get the public path for.
  * @return string                The public URL to the asset, empty string otherwise.
  */
-function get_entry_asset_url( string $dir_entry_name, $filename = 'index.js' ) {
+function get_entry_asset_url( string $dir_entry_name, ?string $filename = 'index.js' ): string {
 	if ( empty( $filename ) ) {
 		return '';
 	}

--- a/tests/Feature/ExampleFeatureTest.php
+++ b/tests/Feature/ExampleFeatureTest.php
@@ -18,7 +18,7 @@ class ExampleFeatureTest extends TestCase {
 	/**
 	 * An example test for the example feature. In practice, this should be updated to test an aspect of the feature.
 	 */
-	public function test_example() {
+	public function test_example(): void {
 		$this->assertTrue( true );
 		$this->assertNotEmpty( home_url() );
 	}

--- a/tests/Unit/ExampleUnitTest.php
+++ b/tests/Unit/ExampleUnitTest.php
@@ -18,7 +18,7 @@ class ExampleUnitTest extends TestCase {
 	/**
 	 * An example unit test. In practice, this should be updated to test a function in isolation.
 	 */
-	public function test_that_true_is_true() {
+	public function test_that_true_is_true(): void {
 		$this->assertTrue( true );
 	}
 }


### PR DESCRIPTION
Adds a [Rector](https://getrector.com/) configuration and resolves #330.

Rector is a very powerful tool to upgrade code and also ensure consistent code. We use it on Mantle to quickly add types to the code base as well as deal with the [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) change in PHP 8.4. We also just used it on NYP to upgrade to PHPUnit 11 from 9 without any self-written code. 

Future plans: it may be wise to use https://github.com/fsylum/rector-wordpress to keep our plugins automatically up-to-date. Think of https://github.com/fsylum/rector-wordpress/tree/main/config/sets as very easy ways to upgrade a project to a new WordPress version.