### PR TITLE
Render the XML XSD of the phpunit that is installed on the project

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
   bootstrap="tests/bootstrap.php"
   backupGlobals="false"
   colors="true"


### PR DESCRIPTION
I have been doing this recently to make upgrades to PHPUnit a bit more seamless when the `phpunit.xml` file is referencing the actual XSD installed locally.