### PR TITLE
Adding a composer dev command to host the plugin and npm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@
 /tests export-ignore
 /configure.php export-ignore
 /Makefile export-ignore
+/.wp-env.json export-ignore
 
 #
 # Auto detect text files and perform LF normalization.

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,4 @@
+{
+  "core": null,
+  "plugins": [ "." ]
+}

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://schemas.wp.org/trunk/wp-env.json",
   "core": null,
   "plugins": [ "." ]
 }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ $plugin = Create_WordPress_Plugin\Skeleton\Example_Plugin();
 $plugin->perform_magic();
 ```
 <!--front-end-->
+## Development
+
+To setup a WordPress installation and run the plugin in a local environment, you
+can use `wp-env` via the `composer dev` command:
+
+```sh
+npm install
+composer dev
+```
+
+The command will start a local WordPress environment with the plugin activated
+while also running the front-end assets build process. You can also run `npm run
+start` to start the front-end assets build process separately. The front-end
+assets will be compiled into the `build` directory and will be enqueued
+automatically by the plugin.
+
 ## Testing
 
 Run `npm run test` to run Jest tests against JavaScript files. Run

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,10 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "scripts": {
+    "dev": [
+      "Composer\\Config::disableProcessTimeout",
+      "npx concurrently -c \"#93c5fd,#fdba74\" \"composer serve\" \"npm run start\" --names=server,webpack"
+    ],
     "phpcbf": "phpcbf .",
     "phpcs": "phpcs .",
     "phpstan": "phpstan --memory-limit=512M",
@@ -64,6 +68,7 @@
     "rector:fix": "rector process",
     "rector": "rector process --dry-run",
     "release": "npx @alleyinteractive/create-release@latest",
+    "serve": "command -v wp-env >/dev/null 2>&1 || npm install -g @wordpress/env && wp-env start",
     "test": [
       "@lint",
       "@phpunit"

--- a/composer.json
+++ b/composer.json
@@ -1,72 +1,72 @@
 {
-    "name": "alleyinteractive/create-wordpress-plugin",
-    "description": "A skeleton WordPress plugin",
-    "type": "wordpress-plugin",
-    "keywords": [
-        "alleyinteractive",
-        "create-wordpress-plugin"
-    ],
-    "homepage": "https://github.com/alleyinteractive/create-wordpress-plugin",
-    "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "author_name",
-            "email": "email@domain.com"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "alleyinteractive/composer-wordpress-autoloader": "^1.0",
-        "alleyinteractive/wp-type-extensions": "^4.0"
-    },
-    "require-dev": {
-        "alleyinteractive/alley-coding-standards": "^2.0",
-        "mantle-framework/testkit": "^1.4",
-        "rector/rector": "^2.0",
-        "szepeviktor/phpstan-wordpress": "^2.0"
-    },
-    "config": {
-        "allow-plugins": {
-            "alleyinteractive/composer-wordpress-autoloader": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "pestphp/pest-plugin": true
-        },
-        "sort-packages": true
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Alley\\WP\\Create_WordPress_Plugin\\Tests\\": "tests"
-        }
-    },
-    "extra": {
-        "wordpress-autoloader": {
-            "autoload": {
-                "Alley\\WP\\Create_WordPress_Plugin\\": "src"
-            }
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "scripts": {
-        "phpcbf": "phpcbf .",
-        "phpcs": "phpcs .",
-        "phpstan": "phpstan --memory-limit=512M",
-        "lint": [
-            "@phpcs",
-            "@phpstan",
-            "@rector"
-        ],
-        "lint:fix": [
-          "@rector:fix",
-          "@phpcbf"
-        ],
-        "phpunit": "phpunit",
-        "rector:fix": "rector process",
-        "rector": "rector process --dry-run",
-        "release": "npx @alleyinteractive/create-release@latest",
-        "test": [
-            "@lint",
-            "@phpunit"
-        ]
+  "name": "alleyinteractive/create-wordpress-plugin",
+  "description": "A skeleton WordPress plugin",
+  "type": "wordpress-plugin",
+  "keywords": [
+    "alleyinteractive",
+    "create-wordpress-plugin"
+  ],
+  "homepage": "https://github.com/alleyinteractive/create-wordpress-plugin",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "author_name",
+      "email": "email@domain.com"
     }
+  ],
+  "require": {
+    "php": "^8.2",
+    "alleyinteractive/composer-wordpress-autoloader": "^1.0",
+    "alleyinteractive/wp-type-extensions": "^4.0"
+  },
+  "require-dev": {
+    "alleyinteractive/alley-coding-standards": "^2.0",
+    "mantle-framework/testkit": "^1.4",
+    "rector/rector": "^2.0",
+    "szepeviktor/phpstan-wordpress": "^2.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "alleyinteractive/composer-wordpress-autoloader": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "pestphp/pest-plugin": true
+    },
+    "sort-packages": true
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Alley\\WP\\Create_WordPress_Plugin\\Tests\\": "tests"
+    }
+  },
+  "extra": {
+    "wordpress-autoloader": {
+      "autoload": {
+        "Alley\\WP\\Create_WordPress_Plugin\\": "src"
+      }
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "scripts": {
+    "phpcbf": "phpcbf .",
+    "phpcs": "phpcs .",
+    "phpstan": "phpstan --memory-limit=512M",
+    "lint": [
+      "@phpcs",
+      "@phpstan",
+      "@rector"
+    ],
+    "lint:fix": [
+      "@rector:fix",
+      "@phpcbf"
+    ],
+    "phpunit": "phpunit",
+    "rector:fix": "rector process",
+    "rector": "rector process --dry-run",
+    "release": "npx @alleyinteractive/create-release@latest",
+    "test": [
+      "@lint",
+      "@phpunit"
+    ]
+  }
 }

--- a/configure.php
+++ b/configure.php
@@ -671,6 +671,16 @@ if ( confirm( 'Will this plugin be compiling front-end assets (Node)?', true ) )
 		]
 	);
 
+	if ( file_exists( 'composer.json' ) ) {
+		$plugin_composer = (array) json_decode( (string) file_get_contents( 'composer.json' ), true );
+
+		if ( isset( $plugin_composer['scripts']['dev'] ) ) {
+			unset( $plugin_composer['scripts']['dev'] );
+
+			file_put_contents( 'composer.json', json_encode( $plugin_composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		}
+	}
+
 	remove_assets_readme( keep_contents: false );
 	remove_assets_require();
 	remove_assets_test();

--- a/configure.php
+++ b/configure.php
@@ -203,6 +203,7 @@ function remove_project_files(): void {
 		'.gitignore',
 		'.gitattributes',
 		'.github',
+		'.wp-env.json',
 		'LICENSE',
 	];
 
@@ -389,13 +390,15 @@ function remove_phpstan(): void {
 	if ( file_exists( 'composer.json' ) ) {
 		$composer_json = (array) json_decode( (string) file_get_contents( 'composer.json' ), true );
 
+		unset( $composer_json['require-dev']['szepeviktor/phpstan-wordpress'] ); // @phpstan-ignore-line
+
 		if ( isset( $composer_json['scripts']['phpstan'] ) ) { // @phpstan-ignore-line
 			unset( $composer_json['scripts']['phpstan'] ); // @phpstan-ignore-line
 
-			$composer_json['scripts']['test'] = [ // @phpstan-ignore-line
-				'@phpcs',
-				'@phpunit',
-			];
+			$composer_json['scripts']['lint'] = array_filter(
+				$composer_json['scripts']['lint'] ?? [],
+				fn ( string $script ) => ! str_contains( $script, 'phpstan' ),
+			);
 
 			file_put_contents( 'composer.json', json_encode( $composer_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 		}


### PR DESCRIPTION
- Moves `composer.json` to be 2 space indented.
- Adds `wp-env` and a config file.
- Adds a `composer dev` command that will start the server and also run `npm run start` with output logs.
- Fixes issue with removing PHPStan during configuration.

## Example output of `composer dev`:
![CleanShot 2025-07-07 at 14 06 11@2x](https://github.com/user-attachments/assets/8642e40a-fd12-456a-a6c2-362b1822bda1)


