### PR TITLE
Drop ajv package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@alleyinteractive/tsconfig": "^0.3.0",
         "@babel/preset-env": "^7.28.3",
         "@wordpress/babel-preset-default": "^8.8.2",
-        "ajv": "^8.17.1",
         "babel-jest": "^30.0.5",
         "jest": "^30.0.5",
         "ts-jest": "^29.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@alleyinteractive/tsconfig": "^0.3.0",
     "@babel/preset-env": "^7.28.3",
     "@wordpress/babel-preset-default": "^8.8.2",
-    "ajv": "^8.17.1",
     "babel-jest": "^30.0.5",
     "jest": "^30.0.5",
     "ts-jest": "^29.4.1",


### PR DESCRIPTION
Testing of https://github.com/alleyinteractive/alley-scripts/issues/686

```
create-wordpress-plugin@ /Users/srtfisher/broadway/www/wordpress/wp-content/plugins/create-wordpress-plugin
├─┬ @alleyinteractive/build-tool@0.2.0
│ ├─┬ @wordpress/scripts@30.10.0
│ │ ├─┬ npm-package-json-lint@6.4.0
│ │ │ ├─┬ ajv-errors@1.0.1
│ │ │ │ └── ajv@8.17.1 deduped
│ │ │ └── ajv@6.12.6
│ │ ├─┬ schema-utils@4.3.0
│ │ │ ├─┬ ajv-formats@2.1.1
│ │ │ │ └── ajv@8.17.1 deduped
│ │ │ ├─┬ ajv-keywords@5.1.0
│ │ │ │ └── ajv@8.17.1 deduped
│ │ │ └── ajv@8.17.1
│ │ └─┬ url-loader@4.1.1
│ │   └─┬ schema-utils@3.3.0
│ │     ├─┬ ajv-keywords@3.5.2
│ │     │ └── ajv@6.12.6 deduped
│ │     └── ajv@6.12.6
│ └─┬ webpack@5.97.1
│   └─┬ schema-utils@3.3.0
│     ├─┬ ajv-keywords@3.5.2
│     │ └── ajv@6.12.6 deduped
│     └── ajv@6.12.6
├─┬ @alleyinteractive/eslint-config@0.2.0
│ └─┬ eslint@8.57.1
│   ├─┬ @eslint/eslintrc@2.1.4
│   │ └── ajv@6.12.6
│   └── ajv@6.12.6
└─┬ @alleyinteractive/stylelint-config@0.0.2
  └─┬ stylelint@16.14.1
    └─┬ table@6.9.0
      └── ajv@8.17.1 deduped
```