### PR TITLE
Fix high-severity npm audit failure (fast-uri)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23031,9 +23031,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "devOptional": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "ts-jest": "^29.4.5",
     "typescript": "^5.9.3",
     "webpack-cli": "^6.0.1"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.2"
   }
 }


### PR DESCRIPTION
## Problem

PR CI was red across all PHP matrix jobs — but the failure was in the **Node Tests** step, not PHP. The step runs:

```
npm audit --audit-level=high --omit=dev
```

which failed on a **high**-severity advisory in `fast-uri@<=3.1.1`:

- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path traversal via percent-encoded dot segments
- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — host confusion via percent-encoded authority delimiters

`fast-uri` is pulled in transitively via `ajv` and the `@wordpress/*` packages, so it's present even with `--omit=dev`. Pre-existing on `develop` (reproduced on a clean checkout).

## Fix

Add an npm `overrides` pinning `fast-uri` to `^3.1.2` — the patched 3.x release, which satisfies `ajv`'s `^3.0.1` constraint, so nothing breaks:

```jsonc
"overrides": {
  "fast-uri": "^3.1.2"
}
```

## Verification

- `npm audit --audit-level=high --omit=dev` → exits **0** (32 moderate remain, no high/critical — tolerated by `--audit-level=high`, consistent with #536).
- `npm run build` compiles successfully; `jest` passes.
- `fast-uri` resolves to `3.1.2` (`npm ls fast-uri`).

The remaining moderate advisories (`@babel/runtime`, `uuid`, `showdown`, `postcss`) have no non-breaking fix and don't fail the build; left as-is per the existing high-only policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)