### PR TITLE
Use mantle.alley.com schema URL for meta.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Every directory under `entries/` is a webpack entry point compiled to `build/<na
 Dynamic blocks live in `blocks/<name>/` (scaffolded by `npm run create-block`).
 
 ### Meta
-`config/post-meta.json` and `config/term-meta.json` drive `register_meta_from_file()` from `mantle-framework/support`. Add meta by editing these JSON files — no PHP changes needed. Schema: `https://raw.githubusercontent.com/alleyinteractive/mantle-framework/HEAD/src/mantle/support/schema/meta.json`.
+`config/post-meta.json` and `config/term-meta.json` drive `register_meta_from_file()` from `mantle-framework/support`. Add meta by editing these JSON files — no PHP changes needed. Schema: `https://mantle.alley.com/schema/meta.json`.
 
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The plugin supports registering post and term meta via JSON files located in the
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/alleyinteractive/mantle-framework/HEAD/src/Mantle/Support/schema/meta.json",
+  "$schema": "https://mantle.alley.com/schema/meta.json",
   "example_meta_key": {
     "post_types": "article",
     "type": "string"


### PR DESCRIPTION
Updates the `meta.json` `$schema` reference from the raw GitHub URL to the canonical `https://mantle.alley.com/schema/meta.json`.

## Changes
- `README.md` — meta registration example `$schema`
- `CLAUDE.md` — schema reference in the Meta architecture note