### PR TITLE
Add a `// Add features here.` marker inside the default Group

### DIFF
--- a/src/main.php
+++ b/src/main.php
@@ -16,6 +16,7 @@ function main(): void {
 	$plugin = new Group(
 		new Features\Register_Block_Manifest(),
 		new Features\Load_Entries( cache: 'local' !== wp_get_environment_type() ),
+		// Add features here.
 	);
 
 	/*


### PR DESCRIPTION
See https://github.com/alleyinteractive/create-wordpress-project/pull/214 for context.

tl;dr search and replace didn't work as expected. 

create-wordpress-project wires its bundled features into a generated plugin by replacing a // Add features here. marker inside src/main.php's Group ([main.php L16–L19](https://github.com/alleyinteractive/create-wordpress-plugin/blob/fc3b7af/src/main.php#L16-L19)). This template doesn't carry that marker anymore, so the replace does nothing and those features ship switched off.

Fix: add it back, two tabs in at the Group's indentation.

Ships with the create-wordpress-project PR that trims features.txt and lines its marker up. They go out together.

Note: this was generated with the help of Claude Code, be suspicious of its accuracy.