### PR TITLE
Issue-544: Fix the configure script's search and replace

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -36,7 +36,7 @@
   <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
     <properties>
       <property name="prefixes" type="array">
-        <element value="vendor_name" />
+        <element value="vendor_prefix" />
         <element value="alley" />
         <element value="create_wordpress_plugin" />
       </property>

--- a/.scaffolder/plugin-feature/feature.php.hbs
+++ b/.scaffolder/plugin-feature/feature.php.hbs
@@ -2,7 +2,7 @@
 /**
  * {{ wpClassName inputs.featureName }} class file
  *
- * @package Create_WordPress_Plugin
+ * @package create-wordpress-plugin
  */
 
 namespace Alley\WP\Create_WordPress_Plugin\\{{ wpNamespace inputs.featureName prefix="Features" }};

--- a/.scaffolder/plugin-feature/test.php.hbs
+++ b/.scaffolder/plugin-feature/test.php.hbs
@@ -7,8 +7,8 @@
 
 namespace Alley\WP\Create_WordPress_Plugin\\{{ wpNamespace inputs.featureName prefix="Tests\Features" }};
 
-use Create_WordPress_Plugin\Tests\TestCase;
-use Create_WordPress_Plugin\\{{ wpNamespace inputs.featureName prefix="Features" }}\\{{ wpClassName inputs.featureName }};
+use Alley\WP\Create_WordPress_Plugin\Tests\TestCase;
+use Alley\WP\Create_WordPress_Plugin\\{{ wpNamespace inputs.featureName prefix="Features" }}\\{{ wpClassName inputs.featureName }};
 
 /**
  * {{ replace (psr4ClassName inputs.featureName) "_" " " }} Test for the {{ wpClassName inputs.featureName }} class.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-A **skeleton/template WordPress plugin** maintained by Alley Interactive. Consumers click "Use template" on GitHub, then run `make` (or `php ./configure.php`) to replace placeholders (plugin name, author, namespace, etc.) throughout the files. Most changes in this repo are to the template itself — keep placeholder tokens like `create-wordpress-plugin`, `Create_WordPress_Plugin`, `author_name`, `author_username` intact unless the task is to change them.
+A **skeleton/template WordPress plugin** maintained by Alley Interactive. Consumers click "Use template" on GitHub, then run `make` (or `php ./configure.php`) to replace placeholders (plugin name, author, namespace, etc.) throughout the files. Most changes in this repo are to the template itself — keep the placeholder tokens that `configure.php` replaces (its `$search_and_replace` map) intact unless the task is to change them.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ composer require alleyinteractive/create-wordpress-plugin
 Activate the plugin in WordPress and use it like so:
 
 ```php
-$plugin = Create_WordPress_Plugin\Skeleton\Example_Plugin();
+$plugin = Alley\WP\Create_WordPress_Plugin\Example_Plugin();
 $plugin->perform_magic();
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A skeleton WordPress plugin",
   "type": "wordpress-plugin",
   "keywords": [
-    "alleyinteractive",
+    "vendor_slug",
     "create-wordpress-plugin"
   ],
   "homepage": "https://github.com/alleyinteractive/create-wordpress-plugin",

--- a/configure.php
+++ b/configure.php
@@ -171,7 +171,8 @@ function remove_composer_wrapper_comments(): void {
 
 	$contents = file_get_contents( $plugin_file );
 
-	if ( empty( $contents ) ) {
+	// The comments are gone when the loader itself has already been removed.
+	if ( empty( $contents ) || ! str_contains( $contents, '/* Start Composer Loader */' ) ) {
 		return;
 	}
 
@@ -220,22 +221,33 @@ function remove_configure_test(): void {
 		return;
 	}
 
-	$composer_json = (array) json_decode( (string) file_get_contents( 'composer.json' ), true );
+	$contents = (string) file_get_contents( 'composer.json' );
 
-	if ( ! isset( $composer_json['scripts']['test:configure'] ) ) {
+	if ( ! str_contains( $contents, 'test:configure' ) ) {
 		return;
 	}
 
-	unset( $composer_json['scripts']['test:configure'] );
+	// Drop the script and the reference to it in `composer test` line by line,
+	// which leaves the rest of the file formatted as it was.
+	$updated = (string) preg_replace( '/^[^\S\n]*"@?test:configure".*\n/m', '', $contents );
 
-	$composer_json['scripts']['test'] = array_values(
-		array_filter(
-			$composer_json['scripts']['test'] ?? [],
-			fn ( string $script ) => '@test:configure' !== $script,
-		)
-	);
+	if ( ! is_array( json_decode( $updated, true ) ) ) {
+		// The lines couldn't be dropped cleanly, so rewrite the file instead.
+		$composer_json = (array) json_decode( $contents, true );
 
-	file_put_contents( 'composer.json', json_encode( $composer_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		unset( $composer_json['scripts']['test:configure'] );
+
+		$composer_json['scripts']['test'] = array_values(
+			array_filter(
+				$composer_json['scripts']['test'] ?? [],
+				fn ( string $script ) => '@test:configure' !== $script,
+			)
+		);
+
+		$updated = (string) json_encode( $composer_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+	}
+
+	file_put_contents( 'composer.json', $updated );
 }
 
 function rollup_phpcs_to_parent( string $parent_file, string $local_file, string $plugin_name, string $plugin_domain ): void {
@@ -370,7 +382,6 @@ function list_all_files_for_replacement(): array {
 		'vendor',
 		'node_modules',
 		'.phpcs',
-		'.scaffolder',
 	];
 
 	$exclude = array_map(
@@ -422,9 +433,11 @@ function remove_phpstan(): void {
 		if ( isset( $composer_json['scripts']['phpstan'] ) ) { // @phpstan-ignore-line
 			unset( $composer_json['scripts']['phpstan'] ); // @phpstan-ignore-line
 
-			$composer_json['scripts']['lint'] = array_filter(
-				$composer_json['scripts']['lint'] ?? [],
-				fn ( string $script ) => ! str_contains( $script, 'phpstan' ),
+			$composer_json['scripts']['lint'] = array_values(
+				array_filter(
+					$composer_json['scripts']['lint'] ?? [],
+					fn ( string $script ) => ! str_contains( $script, 'phpstan' ),
+				)
 			);
 
 			file_put_contents( 'composer.json', json_encode( $composer_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
@@ -616,9 +629,18 @@ $search_and_replace = [
 
 	'A skeleton WordPress plugin' => $description,
 
-	// Extra slashes are here for composer.json.
-	'Alley\\\WP\\\Create_WordPress_Plugin\\\\' => str_replace( '\\', '\\\\', $namespace ) . '\\\\',
-	'Alley\WP\Create_WordPress_Plugin'         => $namespace,
+	// This skeleton's own repository, which has to be replaced before the slug
+	// below so that references to Alley's other repositories and packages
+	// (composer requirements, GitHub actions, npm packages) are left alone.
+	'alleyinteractive/create-wordpress-plugin' => "{$vendor_slug}/{$plugin_name_slug}",
+
+	// Extra slashes are here for JSON files, such as composer.json.
+	'Alley\\\WP\\\Create_WordPress_Plugin' => str_replace( '\\', '\\\\', $namespace ),
+	'Alley\WP\Create_WordPress_Plugin'     => $namespace,
+
+	// The last segment of the namespace, which is used on its own by the
+	// scaffolder configuration.
+	'Create_WordPress_Plugin'     => str_after( $namespace, '\\' ),
 
 	'Example_Plugin'              => $class_name,
 	'create_wordpress_plugin'     => str_replace( '-', '_', $plugin_name_slug ),
@@ -630,7 +652,8 @@ $search_and_replace = [
 	'CREATE_WORDPRESS_PLUGIN'     => strtoupper( str_replace( '-', '_', $plugin_name_slug ) ),
 	'Skeleton'                    => $class_name,
 	'vendor_name'                 => $vendor_name,
-	'alleyinteractive'            => $vendor_slug,
+	'vendor_slug'                 => $vendor_slug,
+	'vendor_prefix'               => str_replace( '-', '_', $vendor_slug ),
 	'plugin.php'                  => $plugin_file,
 ];
 
@@ -716,8 +739,6 @@ if ( confirm( 'Will this plugin be compiling front-end assets (Node)?', true ) )
 if ( confirm( 'Will this plugin be using Composer? (WordPress Composer Autoloader is already included! phpcs and phpunit also rely on Composer being installed for testing.)', true ) ) {
 	$uses_composer = true;
 	$needs_built_assets = true;
-
-	remove_composer_wrapper_comments();
 
 	if ( confirm( 'Do you want to run `composer install`?', true ) ) {
 		if ( file_exists( __DIR__ . '/composer.lock' ) ) {
@@ -836,6 +857,13 @@ if (
 	if ( confirm( 'Do you want to remove the git repository for the plugin?', true ) ) {
 		delete_files( '.git' );
 	}
+}
+
+// Tidy up the comments that wrap the Composer loader now that every prompt that
+// can remove the loader entirely has been answered. Removing the loader relies
+// on these comments to find it.
+if ( $uses_composer ) {
+	remove_composer_wrapper_comments();
 }
 
 if ( $standalone && confirm( 'Do you want to use SQLite for unit testing? (This is a great way to speed up your tests!)', true ) ) {

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -57,7 +57,7 @@ lyrics would be passed in when the feature was called, as shown above.
 /**
  * Feature implementation of hello.php
  *
- * @package Create_WordPress_Plugin
+ * @package create-wordpress-plugin
  */
 
 namespace Alley\WP\Create_WordPress_Plugin\Features;

--- a/tests/ConfigureTest.php
+++ b/tests/ConfigureTest.php
@@ -50,6 +50,7 @@ final class ConfigureTest extends PHPUnit_Test_Case {
 		'A skeleton WordPress plugin',
 		'CREATE_WORDPRESS_PLUGIN',
 		'Create WordPress Plugin',
+		'Create_WordPress_Plugin',
 		'Example_Plugin',
 		'Skeleton',
 		'author_name',
@@ -58,6 +59,8 @@ final class ConfigureTest extends PHPUnit_Test_Case {
 		'create_wordpress_plugin',
 		'email@domain.com',
 		'vendor_name',
+		'vendor_prefix',
+		'vendor_slug',
 	];
 
 	/**
@@ -66,7 +69,6 @@ final class ConfigureTest extends PHPUnit_Test_Case {
 	 * @var array<int, string>
 	 */
 	private const UNTOUCHED_PATHS = [
-		'.scaffolder/',
 		'LICENSE',
 		'composer.lock',
 		'tests/ConfigureTest.php',
@@ -167,6 +169,7 @@ final class ConfigureTest extends PHPUnit_Test_Case {
 
 		$this->assertStringContainsString( 'PHP_CodeSniffer standard for wp-my-cool-plugin.', $phpcs );
 		$this->assertStringContainsString( '<element value="wp_my_cool_plugin" />', $phpcs );
+		$this->assertStringContainsString( '<element value="test_vendor" />', $phpcs );
 
 		// The prefixed cache key and constant used by the features.
 		$entries = $this->read( $plugin . '/src/features/class-load-entries.php' );
@@ -289,11 +292,14 @@ final class ConfigureTest extends PHPUnit_Test_Case {
 		$this->assertFileDoesNotExist( $plugin . '/Makefile' );
 		$this->assertFileDoesNotExist( $plugin . '/tests/ConfigureTest.php' );
 
-		$scripts = $this->read_json( $plugin . '/composer.json' )['scripts'];
+		$composer = $this->read( $plugin . '/composer.json' );
+		$scripts  = $this->read_json( $plugin . '/composer.json' )['scripts'];
 
 		$this->assertArrayNotHasKey( 'test:configure', $scripts );
-		$this->assertNotContains( '@test:configure', $scripts['test'] );
-		$this->assertContains( '@phpunit', $scripts['test'] );
+		$this->assertSame( [ '@lint', '@phpunit' ], $scripts['test'] );
+
+		// Removing the script should not reformat the rest of the file.
+		$this->assertStringContainsString( "\n  \"name\": \"test-vendor/wp-my-cool-plugin\",", $composer );
 	}
 
 	/**
@@ -488,8 +494,9 @@ final class ConfigureTest extends PHPUnit_Test_Case {
 
 		$this->assertArrayNotHasKey( 'szepeviktor/phpstan-wordpress', $composer['require-dev'] );
 		$this->assertArrayNotHasKey( 'phpstan', $composer['scripts'] );
-		$this->assertNotContains( '@phpstan', $composer['scripts']['lint'] );
-		$this->assertContains( '@phpcs', $composer['scripts']['lint'] );
+
+		// A JSON list, not an object with the PHPStan key punched out of it.
+		$this->assertSame( [ '@phpcs', '@rector' ], $composer['scripts']['lint'] );
 	}
 
 	/**
@@ -592,16 +599,12 @@ final class ConfigureTest extends PHPUnit_Test_Case {
 		$this->assertTrue( $composer['config']['allow-plugins']['alleyinteractive/composer-wordpress-autoloader'] );
 		$this->assertSame( $this->sorted( array_keys( $composer['require'] ) ), array_keys( $composer['require'] ) );
 
-		/*
-		 * Known issue: the Composer loader is left in the plugin file, even
-		 * though the script reports removing it. Its wrapper comments were
-		 * already stripped when Composer was confirmed, so the block can no
-		 * longer be matched. Update this when the script is fixed.
-		 */
-		$this->assertStringContainsString(
-			"require_once __DIR__ . '/vendor/wordpress-autoload.php';",
-			$this->read( $plugin . '/wp-my-cool-plugin.php' ),
-		);
+		// The Composer loader is no longer needed in the plugin file.
+		$main = $this->read( $plugin . '/wp-my-cool-plugin.php' );
+
+		$this->assertStringNotContainsString( 'wordpress-autoload.php', $main );
+		$this->assertStringNotContainsString( 'Composer Loader', $main );
+		$this->assertStringContainsString( "require_once __DIR__ . '/src/main.php';", $main );
 
 		// The PHPCS configuration inherits from the parent project.
 		$phpcs = $this->read( $plugin . '/.phpcs.xml' );
@@ -714,40 +717,104 @@ final class ConfigureTest extends PHPUnit_Test_Case {
 	}
 
 	/**
-	 * The placeholders the script does not replace today.
-	 *
-	 * This documents the current behavior rather than endorsing it: the bare
-	 * `Create_WordPress_Plugin` token is only replaced as part of the full
-	 * `Alley\WP\Create_WordPress_Plugin` namespace, and the `.scaffolder`
-	 * directory is excluded from the search and replace entirely. Update this
-	 * test when the script is taught to replace them.
+	 * References to Alley's own packages, actions and repositories are not the
+	 * plugin's vendor and should survive being scaffolded by someone else.
 	 */
-	public function test_documents_the_placeholders_that_are_left_behind(): void {
+	public function test_keeps_references_to_third_party_packages(): void {
+		$plugin   = $this->configure( $this->default_answers() );
+		$composer = $this->read_json( $plugin . '/composer.json' );
+
+		$this->assertArrayHasKey( 'alleyinteractive/composer-wordpress-autoloader', $composer['require'] );
+		$this->assertArrayHasKey( 'alleyinteractive/wp-type-extensions', $composer['require'] );
+		$this->assertArrayHasKey( 'alleyinteractive/alley-coding-standards', $composer['require-dev'] );
+		$this->assertTrue( $composer['config']['allow-plugins']['alleyinteractive/composer-wordpress-autoloader'] );
+
+		$workflows = $this->read( $plugin . '/.github/workflows/all-pr-tests.yml' )
+			. $this->read( $plugin . '/.github/workflows/built-release.yml' )
+			. $this->read( $plugin . '/.github/workflows/upgrade-wordpress-plugin.yml' );
+
+		$this->assertStringContainsString( 'uses: alleyinteractive/action-test-general@develop', $workflows );
+		$this->assertStringContainsString( 'uses: alleyinteractive/action-test-node@develop', $workflows );
+		$this->assertStringContainsString( 'uses: alleyinteractive/action-test-php@develop', $workflows );
+		$this->assertStringContainsString( 'uses: alleyinteractive/action-release@develop', $workflows );
+		$this->assertStringContainsString( 'uses: alleyinteractive/action-update-wordpress-plugin@', $workflows );
+
+		$this->assertStringContainsString(
+			'"@alleyinteractive/build-tool"',
+			$this->read( $plugin . '/package.json' ),
+		);
+
+		// Alley's documentation links are not the plugin's repository either.
+		$this->assertStringContainsString(
+			'https://github.com/alleyinteractive/action-release',
+			$this->read( $plugin . '/README.md' ),
+		);
+	}
+
+	/**
+	 * The skeleton's own repository, on the other hand, becomes the plugin's.
+	 */
+	public function test_replaces_the_skeletons_own_repository(): void {
+		$plugin   = $this->configure( $this->default_answers() );
+		$composer = $this->read_json( $plugin . '/composer.json' );
+
+		$this->assertSame( 'test-vendor/wp-my-cool-plugin', $composer['name'] );
+		$this->assertSame( 'https://github.com/test-vendor/wp-my-cool-plugin', $composer['homepage'] );
+		$this->assertSame( [ 'test-vendor', 'wp-my-cool-plugin' ], $composer['keywords'] );
+
+		$this->assertStringContainsString(
+			'Plugin URI: https://github.com/test-vendor/wp-my-cool-plugin',
+			$this->read( $plugin . '/wp-my-cool-plugin.php' ),
+		);
+
+		$readme = $this->read( $plugin . '/README.md' );
+
+		$this->assertStringContainsString( 'composer require test-vendor/wp-my-cool-plugin', $readme );
+		$this->assertStringContainsString(
+			'https://github.com/test-vendor/wp-my-cool-plugin/actions/workflows/all-pr-tests.yml',
+			$readme,
+		);
+	}
+
+	/**
+	 * The scaffolder templates generate code for the configured plugin, so they
+	 * need the placeholders replaced as well.
+	 */
+	public function test_replaces_the_placeholders_in_the_scaffolder_templates(): void {
 		$plugin = $this->configure( $this->default_answers() );
-		$found  = $this->find_placeholders(
-			$plugin,
-			[ 'create-wordpress-plugin', 'Create_WordPress_Plugin' ],
-			[ 'LICENSE', 'composer.lock' ],
+
+		$this->assertStringContainsString(
+			'name: wp-my-cool-plugin@plugin-feature',
+			$this->read( $plugin . '/.scaffolder/plugin-feature/config.yml' ),
 		);
 
-		$this->assertSame(
-			[
-				'.scaffolder/plugin-feature/config.yml',
-				'.scaffolder/plugin-feature/test.php.hbs',
-			],
-			$found['create-wordpress-plugin'] ?? [],
+		$feature = $this->read( $plugin . '/.scaffolder/plugin-feature/feature.php.hbs' );
+
+		$this->assertStringContainsString( '@package wp-my-cool-plugin', $feature );
+		$this->assertStringContainsString(
+			'namespace Test_Vendor\My_Cool_Plugin\\\\{{ wpNamespace inputs.featureName prefix="Features" }};',
+			$feature,
 		);
 
+		$test = $this->read( $plugin . '/.scaffolder/plugin-feature/test.php.hbs' );
+
+		$this->assertStringContainsString( 'use Test_Vendor\My_Cool_Plugin\Tests\TestCase;', $test );
+		$this->assertStringContainsString(
+			'namespace Test_Vendor\My_Cool_Plugin\\\\{{ wpNamespace inputs.featureName prefix="Tests\Features" }};',
+			$test,
+		);
+
+		// The entry and block scaffolding config, which uses the last segment of
+		// the namespace on its own.
 		$this->assertSame(
 			[
-				'.scaffolder/plugin-feature/feature.php.hbs',
-				'.scaffolder/plugin-feature/test.php.hbs',
-				'CLAUDE.md',
-				'README.md',
-				'scaffold/config.json',
-				'src/features/README.md',
+				'core_term_meta' => true,
+				'domain'         => 'wp-my-cool-plugin',
+				'folder'         => 'src',
+				'namespace'      => 'My_Cool_Plugin',
+				'require_path'   => '__DIR__',
 			],
-			$found['Create_WordPress_Plugin'] ?? [],
+			$this->read_json( $plugin . '/scaffold/config.json' ),
 		);
 	}
 


### PR DESCRIPTION
Stacked on #546 — the base branch is `feature/issue-544/tests-for-configure-php-regressions`, so review that one first (or read [the diff against it](https://github.com/alleyinteractive/create-wordpress-plugin/compare/feature/issue-544/tests-for-configure-php-regressions...feature/issue-544/fix-configure-php-replacements)).

The tests in #546 documented five defects in `configure.php`. This fixes them and turns those characterization assertions into assertions of the intended behavior.

## The fixes

**Replacing `alleyinteractive` everywhere rewrote every reference to Alley's other packages.** For any vendor other than Alley, a scaffolded plugin got a `composer.json` that cannot install (`test-vendor/composer-wordpress-autoloader`, `test-vendor/wp-type-extensions`, `test-vendor/alley-coding-standards`), workflows pointing at `uses: test-vendor/action-test-php@develop`, and rewritten links to Alley's docs. The map now replaces `alleyinteractive/create-wordpress-plugin` — this skeleton's own repository — ahead of the slug rule, so everything else survives. `composer install --dry-run` in a configured copy now resolves cleanly. The one spot that legitimately wanted the vendor on its own (the `composer.json` keyword) uses a new `vendor_slug` placeholder.

**The bare `Create_WordPress_Plugin` token was never replaced,** only the fully-qualified namespace, so it survived in `scaffold/config.json`'s `"namespace"`, `src/features/README.md`, the README usage example and `CLAUDE.md`. It now maps to the last segment of the namespace, using the `str_after()` helper that was already in the file but unused. The two spots that actually meant the text domain became `create-wordpress-plugin`, the README example was missing its namespace root, and `CLAUDE.md` now points at the replacement map instead of restating tokens that the map then rewrites. The JSON-escaped namespace rule also lost its trailing-`\\` requirement so it matches both the `…\\Tests\\` and `…\\` forms.

**`.scaffolder` was excluded from the search and replace entirely,** so `npm run scaffold` in a configured plugin generated features in `Alley\WP\Create_WordPress_Plugin\Features`. It is included now. The generated test template also referenced `Create_WordPress_Plugin\Tests\TestCase`, a namespace root that never existed — broken in the skeleton too — now `Alley\WP\Create_WordPress_Plugin\Tests\TestCase`.

**The parent-project rollup could not remove the Composer loader.** Confirming Composer ran `remove_composer_wrapper_comments()`, which strips the `/* Start|End Composer Loader */` markers that `remove_composer_require()` later matches on, so the rollup left the loader in place while printing that it had removed it. The comments are now stripped once at the end of the run, after every prompt that can remove the loader outright, and the function returns early when the markers are already gone.

**`remove_phpstan()` left `scripts.lint` as a JSON object** (`{"0": "@phpcs", "2": "@rector"}`) because `array_filter` preserves keys.

Two more while in there:

- The PHPCS global prefix came from the vendor's display name, so `.phpcs.xml` ended up with `<element value="Test Vendor" />` — not a usable prefix. It now uses a `vendor_prefix` token (`test_vendor`).
- `remove_configure_test()` re-encoded `composer.json`, which would have reindented every scaffolded plugin's `composer.json` from two spaces to four. It now drops its two lines textually, falling back to a rewrite only if that would leave invalid JSON.

## Tests

`test_documents_the_placeholders_that_are_left_behind` is gone, replaced by three tests of the real behavior: `test_keeps_references_to_third_party_packages`, `test_replaces_the_skeletons_own_repository` and `test_replaces_the_placeholders_in_the_scaffolder_templates`. `Create_WordPress_Plugin`, `vendor_slug` and `vendor_prefix` joined the placeholder scan, `.scaffolder/` came off the untouched list, the rollup test asserts the loader is gone, and the PHPStan test asserts `scripts.lint === ['@phpcs', '@rector']`.

21 tests / 285 assertions pass, `composer lint` is clean, and the Mantle suite still passes. Each of the five fixes was mutated back to its broken form one at a time to confirm the suite catches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
